### PR TITLE
Add IMAP error handling and rerun flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ If you have Node.js already installed, run:
 $ npx -y google-backup \
   --username "john.doe@gmail.com" \
   --password "abcd efgh ijkl mnop" \
-  --filepath "~/Backups/Google/"
+  --filepath "~/Backups/Google/" \
+  # add this flag to rerun once if an error occurs
+  --rerun-after-error
 ```
 
 > Hint: You can schedule this in a cronjob for automated backups.
@@ -77,3 +79,8 @@ $ docker run \
 ## Also see
 
 Looking to backup iCloud Drive in a similar way? See [iCloud Backup](https://github.com/WeeJeWel/node-icloud-backup).
+
+## Troubleshooting
+
+If the connection drops unexpectedly, use the `--rerun-after-error` flag (or set
+`GOOGLE_BACKUP_RERUN_AFTER_ERROR=1`) to automatically start the backup again.

--- a/bin/google-backup.mjs
+++ b/bin/google-backup.mjs
@@ -14,6 +14,7 @@ program
   .option('-p, --password <password>', 'Google App Password')
   .option('-f, --filepath <filepath>', 'Backup Filepath')
   .option('-s, --services <services>', 'Services to backup. Defaults to mail,calendar,contacts')
+  .option('-r, --rerun-after-error', 'Rerun once when an error occurs')
   .parse();
 
 const options = program.opts();
@@ -22,6 +23,8 @@ const optionUsername = options.username ?? process.env.GOOGLE_BACKUP_USERNAME;
 const optionPassword = options.password ?? process.env.GOOGLE_BACKUP_PASSWORD;
 const optionFilepath = options.filepath ?? process.env.GOOGLE_BACKUP_FILEPATH;
 const optionServices = (options.services ?? process.env.GOOGLE_BACKUP_SERVICES ?? 'mail,calendar,contacts').split(',').map(service => service.trim());
+const optionRerunAfterError = options.rerunAfterError ?? process.env.GOOGLE_BACKUP_RERUN_AFTER_ERROR;
+const rerunAfterError = optionRerunAfterError !== undefined;
 
 const googleBackup = new GoogleBackup({
   username: optionUsername,
@@ -29,8 +32,22 @@ const googleBackup = new GoogleBackup({
   filepath: optionFilepath,
 });
 
-await Promise.all([
-  optionServices.includes('mail') && googleBackup.backupMail(),
-  optionServices.includes('calendar') && googleBackup.backupCalendar(),
-  optionServices.includes('contacts') && googleBackup.backupContacts(),
-]);
+async function runBackup() {
+  await Promise.all([
+    optionServices.includes('mail') && googleBackup.backupMail(),
+    optionServices.includes('calendar') && googleBackup.backupCalendar(),
+    optionServices.includes('contacts') && googleBackup.backupContacts(),
+  ]);
+}
+
+try {
+  await runBackup();
+} catch (err) {
+  console.error(`❌ ${err.message}`);
+  if (rerunAfterError) {
+    console.log('🔁 Rerunning after error...');
+    await runBackup();
+  } else {
+    throw err;
+  }
+}

--- a/lib/GoogleBackupMail.mjs
+++ b/lib/GoogleBackupMail.mjs
@@ -60,6 +60,11 @@ export default class GoogleBackupMail {
       this.imapClient = await imap.connect(this.imapConfig);
       this.log(`✅ Connected to ${this.imapConfig.imap.host}:${this.imapConfig.imap.port}`);
 
+      // Handle unexpected errors without crashing
+      this.imapClient.on('error', err => {
+        this.log(`❌ IMAP client error: ${err.message}`);
+      });
+
       // Get Gmail Mailboxes
       const boxes = await this.imapClient.getBoxes();
 


### PR DESCRIPTION
## Summary
- catch IMAP errors so the client doesn't crash
- add `--rerun-after-error` CLI option and environment variable
- rerun backup once if the flag is set
- document the new flag and troubleshooting advice

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683d3de73680832483ffba30767387ec